### PR TITLE
fix for OA-197

### DIFF
--- a/lib/Request = require(".:lib:request")
+++ b/lib/Request = require(".:lib:request")
@@ -1,0 +1,14 @@
+Request = require("./lib/request")
+
+req = new Request({apiKey: "3359e6b46dfccc305c29", apiSecret: "79faff8d51498a98e7601bf09bba86b0765d4488a34416cce2455f2d82689273","apiEndpoint":"https://playground2api.stagingost.com/v1/"});
+
+req._formatQueryParams("/transaction-types/list/",{request_timestamp: 1527529192});
+
+
+req._formatQueryParams("/actions/",{ request_timestamp: 1527548033, kind: "user_to_user" , name: "C1 1527548033", "currency": "USD", "arbitrary_commission": true, "arbitrary_amount": true});
+
+
+req._formatQueryParams("/actions/",{ request_timestamp: 1527551721, id:"22995,22994"});
+
+
+

--- a/lib/request.js
+++ b/lib/request.js
@@ -17,12 +17,6 @@ const rootPrefix = ".."
   , httpUserAgent = "ost-sdk-js " + version
 ;
 
-/**
- * api key and secret
- *
- * @protected
- */
-const _apiCredentials = {};
 
 /**
  * Generate query signature
@@ -31,9 +25,9 @@ const _apiCredentials = {};
  *
  * @return {string} - query parameters with signature
  *
- * @protected
+ * @private @static
  */
-function signQueryParams(resource, queryParams) {
+function signQueryParams(resource, queryParams, _apiCredentials) {
   const buff = new Buffer.from(_apiCredentials.secret, 'utf8')
     , hmac = crypto.createHmac('sha256', buff);
 
@@ -53,7 +47,9 @@ function signQueryParams(resource, queryParams) {
  * @constructor
  */
 const RequestKlass = function(params) {
-  const oThis = this;
+  const oThis           = this
+      , _apiCredentials = {}
+  ;
 
   // Validate API key
   if (validate.isPresent(params.apiKey)) {
@@ -70,6 +66,17 @@ const RequestKlass = function(params) {
   }
 
   oThis.apiEndpoint = params.apiEndpoint.replace(/\/$/, "");
+
+  oThis._formatQueryParams = function (resource, queryParams) {
+    const oThis = this;
+
+    queryParams.api_key = _apiCredentials.key;
+    queryParams.request_timestamp = Math.round((new Date()).getTime() / 1000);
+
+    var formattedParams = queryString.stringify(queryParams, {arrayFormat: 'bracket'}).replace(/%20/g, '+');
+
+    return signQueryParams(resource, formattedParams, _apiCredentials);
+  }
 };
 
 RequestKlass.prototype = {
@@ -111,14 +118,11 @@ RequestKlass.prototype = {
    * @private
    */
   _formatQueryParams: function (resource, queryParams) {
-    const oThis = this;
-
-    queryParams.api_key = _apiCredentials.key;
-    queryParams.request_timestamp = Math.round((new Date()).getTime() / 1000);
-
-    var formattedParams = queryString.stringify(queryParams, {arrayFormat: 'bracket'}).replace(/%20/g, '+');
-
-    return signQueryParams(resource, formattedParams);
+    /**
+      Note: This is just an empty function body.
+      The Actual code has been moved to constructor.
+      Modifying prototype._formatQueryParams will not have any impact.
+    **/
   },
 
   /**


### PR DESCRIPTION
Issue Description:
Following methods and properties behave as static private:
signQueryParams
_apiCredentials
_apiCredentials.key
_apiCredentials.secret

This means if anyone tries to create multiple instances of sdk with different key/secret pairs, the sdk will use the credentials of latest instance.

Fix:
a. signQueryParams can remain a static private function, but, apiCredentials should be passed to it.
b. _formatQueryParams should not part of prototype, instead.
It should be defined inside constructor and access params (it will be able to access params in constructor as closure will be created).