### PR TITLE
Fix for OA-197

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -17,12 +17,6 @@ const rootPrefix = ".."
   , httpUserAgent = "ost-sdk-js " + version
 ;
 
-/**
- * api key and secret
- *
- * @protected
- */
-const _apiCredentials = {};
 
 /**
  * Generate query signature
@@ -31,9 +25,9 @@ const _apiCredentials = {};
  *
  * @return {string} - query parameters with signature
  *
- * @protected
+ * @private @static
  */
-function signQueryParams(resource, queryParams) {
+function signQueryParams(resource, queryParams, _apiCredentials) {
   const buff = new Buffer.from(_apiCredentials.secret, 'utf8')
     , hmac = crypto.createHmac('sha256', buff);
 
@@ -53,7 +47,9 @@ function signQueryParams(resource, queryParams) {
  * @constructor
  */
 const RequestKlass = function(params) {
-  const oThis = this;
+  const oThis           = this
+      , _apiCredentials = {}
+  ;
 
   // Validate API key
   if (validate.isPresent(params.apiKey)) {
@@ -70,6 +66,17 @@ const RequestKlass = function(params) {
   }
 
   oThis.apiEndpoint = params.apiEndpoint.replace(/\/$/, "");
+
+  oThis._formatQueryParams = function (resource, queryParams) {
+    const oThis = this;
+
+    queryParams.api_key = _apiCredentials.key;
+    queryParams.request_timestamp = Math.round((new Date()).getTime() / 1000);
+
+    var formattedParams = queryString.stringify(queryParams, {arrayFormat: 'bracket'}).replace(/%20/g, '+');
+
+    return signQueryParams(resource, formattedParams, _apiCredentials);
+  }
 };
 
 RequestKlass.prototype = {
@@ -111,14 +118,11 @@ RequestKlass.prototype = {
    * @private
    */
   _formatQueryParams: function (resource, queryParams) {
-    const oThis = this;
-
-    queryParams.api_key = _apiCredentials.key;
-    queryParams.request_timestamp = Math.round((new Date()).getTime() / 1000);
-
-    var formattedParams = queryString.stringify(queryParams, {arrayFormat: 'bracket'}).replace(/%20/g, '+');
-
-    return signQueryParams(resource, formattedParams);
+    /**
+      Note: This is just an empty function body.
+      The Actual code has been moved to constructor.
+      Modifying prototype._formatQueryParams will not have any impact.
+    **/
   },
 
   /**

--- a/test/v1/helper.js
+++ b/test/v1/helper.js
@@ -23,7 +23,7 @@ helperKlass.prototype = {
   OST_KIT_API_SECRET: process.env.OST_KIT_API_SECRET,
   OST_KIT_TRANSFER_FROM_UUID: process.env.OST_KIT_TRANSFER_FROM_UUID,
   OST_KIT_TRANSFER_TO_UUID: process.env.OST_KIT_TRANSFER_TO_UUID,
-  DEBUG: ( "true" === process.env.OST_SDK_JS_DEBUG ),
+  DEBUG: ( "true" === process.env.OST_SDK_DEBUG ),
 
   // helper functions
   responseKeys: function (response) {


### PR DESCRIPTION
Issue Description:
Following methods and properties behave as static private:
signQueryParams
_apiCredentials
_apiCredentials.key
_apiCredentials.secret

This means if anyone tries to create multiple instances of sdk with different key/secret pairs, the sdk will use the credentials of latest instance.

Fix:
a. signQueryParams can remain a static private function, but, apiCredentials should be passed to it.
b. _formatQueryParams should not part of prototype, instead.
It should be defined inside constructor and access params (it will be able to access params in constructor as closure will be created).